### PR TITLE
Feature/non int length parsing

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,7 +48,7 @@ var listCmd = &cobra.Command{
 				if err := podcast.Load(); err != nil {
 					log.Fatalf("Could not load podcast: %#v", err)
 				}
-				fmt.Printf("\t- %-40s (%d episodes)\n", podcast.Name, len(podcast.Episodes))
+                                fmt.Printf("\t%d - %-40s (%d episodes)\n", podcast.ID, podcast.Name, len(podcast.Episodes))
 			}
 		}
 	},

--- a/pcd.go
+++ b/pcd.go
@@ -51,7 +51,6 @@ type Episode struct {
 	Title  string
 	Date   string
 	URL    string
-	Length int
 }
 
 var (
@@ -247,7 +246,6 @@ func parseEpisodes(content io.Reader) ([]Episode, error) {
 			Title:  item.Title.Title,
 			Date:   item.Date.Date,
 			URL:    item.Enclosure.URL,
-			Length: item.Enclosure.Length,
 		}
 
 		episodes = append(episodes, episode)

--- a/rss/parser.go
+++ b/rss/parser.go
@@ -23,8 +23,6 @@ import (
 	"log"
 	"sort"
 	"time"
-        "strings"
-        "strconv"
 )
 
 type PodcastFeed struct {
@@ -69,61 +67,12 @@ type ItemLink struct {
 type Enclosure struct {
 	XMLName xml.Name `xml:"enclosure"`
 	URL     string   `xml:"url,attr"`
-	Length  int      `xml:"length,attr"`
 	Type    string   `xml:"type,attr"`
 }
 
 type PodcastDate struct {
 	XMLName xml.Name `xml:"pubDate"`
 	Date    string   `xml:",chardata"`
-}
-
-/*
-Podcast feeds often use non-integet length values for episodes. When we encounter this
-situation, we need to coerce the value into a usable integer. We accomplish this by
-conforming to the Unmarshaler interface and parsing the relevant xml block ourselves. 
-*/
-func normalizeLength(length string) int {
-    var normalized_length = strings.ToLower(length)
-    normalized_length = strings.ReplaceAll(normalized_length, ",", "")
-    normalized_length = strings.ReplaceAll(normalized_length, " ", "")
-    normalized_length = strings.ReplaceAll(normalized_length, "gb", "000000000")
-    normalized_length = strings.ReplaceAll(normalized_length, "mb", "000000")
-    normalized_length = strings.ReplaceAll(normalized_length, "kb", "000")
-
-    i, err := strconv.Atoi(normalized_length)
-    if err != nil {
-        // handle error
-        log.Print(err)
-    }
-    return i
-}
-
-func (e Enclosure) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-    e.XMLName = start.Name
-
-    for {
-        t, err := d.Token()
-        if err != nil {
-            return err
-        }
-        switch tt := t.(type) {
-        case xml.StartElement:
-            switch tt.Name.Local {
-            case "length":
-                e.Length = normalizeLength(tt.Name.Local)
-            case "type":
-                e.Type = tt.Name.Local
-            case "url":
-                e.URL = tt.Name.Local
-            }
-        log.Print(e)
-        case xml.EndElement:
-            if tt == start.End() {
-                return nil
-            }
-        }
-    }
 }
 
 var (


### PR DESCRIPTION
Podcast RSS feeds often have inconsistent, 0 value, or absent length declarations. Instead of trusting these, check the HTTP header Content-Length property just before downloading. The added benefit here is that if the true file size changes between sync calls it will not impact the progress bar. This can happen when podcast owners replace files with edited copies without changing the URL.